### PR TITLE
Restrict delete permission to admin

### DIFF
--- a/src/collections/Areas.ts
+++ b/src/collections/Areas.ts
@@ -1,11 +1,15 @@
 import type { CollectionConfig } from 'payload'
+import { isAdmin } from './access/isAdmin'
 
 export const Areas: CollectionConfig = {
   slug: 'areas',
+  disableDuplicate: true,
   admin: {
     useAsTitle: 'name', // This ensures the 'name' field is displayed instead of the ID
   },
-
+  access: {
+    delete: isAdmin,
+  },
   fields: [
     {
       name: 'name', // Name of the area

--- a/src/collections/Blocks.ts
+++ b/src/collections/Blocks.ts
@@ -1,9 +1,14 @@
 import type { CollectionConfig } from 'payload'
+import { isAdmin } from './access/isAdmin'
 
 export const Blocks: CollectionConfig = {
   slug: 'blocks',
+  disableDuplicate: true,
   admin: {
     useAsTitle: 'name', // Display the block name instead of ID
+  },
+  access: {
+    delete: isAdmin,
   },
   fields: [
     {

--- a/src/collections/Customers.ts
+++ b/src/collections/Customers.ts
@@ -5,6 +5,7 @@ import { isAdmin } from './access/isAdmin'
 export const Customers: CollectionConfig = {
   slug: 'customers',
   enableQueryPresets: true,
+  disableDuplicate: true,
   admin: {
     useAsTitle: 'name',
     defaultColumns: ['name', 'address', 'lastDelivered', 'area', 'block', 'rate'],
@@ -22,9 +23,9 @@ export const Customers: CollectionConfig = {
         disableListFilter: true,
         hidden: true,
         components: {
-          Cell: '/components/LastDeliveredCell'
-        }
-      }
+          Cell: '/components/LastDeliveredCell',
+        },
+      },
     },
     {
       type: 'tabs',

--- a/src/collections/Employees.ts
+++ b/src/collections/Employees.ts
@@ -1,11 +1,15 @@
 import type { CollectionConfig } from 'payload'
+import { isAdmin } from './access/isAdmin'
 
 export const Employee: CollectionConfig = {
   slug: 'employee',
+  disableDuplicate: true,
   admin: {
     useAsTitle: 'name',
   },
-
+  access: {
+    delete: isAdmin,
+  },
   fields: [
     {
       name: 'name', // Name of the employee

--- a/src/collections/Expenses.ts
+++ b/src/collections/Expenses.ts
@@ -1,10 +1,15 @@
 import { CollectionConfig } from 'payload'
+import { isAdmin } from './access/isAdmin'
 
 export const Expenses: CollectionConfig = {
   slug: 'expenses',
   enableQueryPresets: true,
+  disableDuplicate: true,
   admin: {
     defaultColumns: ['title', 'type', 'amount', 'expenseAt'],
+  },
+  access: {
+    delete: isAdmin,
   },
   fields: [
     {

--- a/src/collections/Invoices.ts
+++ b/src/collections/Invoices.ts
@@ -4,10 +4,12 @@ import { changeTransactionsStatusHook } from '@/hooks/invoices/changeTransaction
 import { calculateAmountsHook } from '@/hooks/invoices/calculateAmounts'
 import { changeTransactionsStatusOnRemoval } from '@/hooks/invoices/changeTransactionsStatusOnRemoval'
 import { unsetOldLatestInvoices } from '@/hooks/invoices/unsetOldLatestInvoices'
+import { isAdmin } from './access/isAdmin'
 
 export const Invoice: CollectionConfig = {
   slug: 'invoice',
   enableQueryPresets: true,
+  disableDuplicate: true,
   hooks: {
     afterChange: [unsetOldLatestInvoices, changeTransactionsStatusOnRemoval],
     afterOperation: [changeTransactionsStatusHook],
@@ -26,6 +28,9 @@ export const Invoice: CollectionConfig = {
       'pdf',
       'sendInvoice',
     ],
+  },
+  access: {
+    delete: isAdmin,
   },
   fields: [
     {

--- a/src/collections/Transactions.ts
+++ b/src/collections/Transactions.ts
@@ -3,10 +3,12 @@ import type { CollectionConfig } from 'payload'
 import { calculateRemainingBottles } from '@/hooks/transactions/remainingBottles'
 import { calculateTotalHook } from '@/hooks/transactions/total'
 import { transactionUpdateForCustomer } from '@/hooks/transactions/transactionUpdateForCustomer'
+import { isAdmin } from './access/isAdmin'
 
 export const Transaction: CollectionConfig = {
   slug: 'transaction',
   enableQueryPresets: true,
+  disableDuplicate: true,
   admin: {
     pagination: {
       defaultLimit: 50,
@@ -23,6 +25,9 @@ export const Transaction: CollectionConfig = {
       'trip',
     ],
   },
+  access: {
+    delete: isAdmin,
+  },
   hooks: {
     afterChange: [],
     beforeChange: [calculateRemainingBottles, calculateTotalHook, transactionUpdateForCustomer],
@@ -34,7 +39,7 @@ export const Transaction: CollectionConfig = {
       relationTo: 'trips',
       admin: {
         sortOptions: '-tripAt',
-      }
+      },
     },
     {
       name: 'customer',
@@ -49,9 +54,9 @@ export const Transaction: CollectionConfig = {
       admin: {
         hidden: true,
         components: {
-          Cell: '/components/LastDeliveredCell'
-        }
-      }
+          Cell: '/components/LastDeliveredCell',
+        },
+      },
     },
     {
       name: 'status',

--- a/src/collections/Trips.ts
+++ b/src/collections/Trips.ts
@@ -3,6 +3,7 @@ import { format } from 'date-fns'
 
 import { createTransactionsOnTripCreate } from '@/hooks/trips/createTransactionsOnTripCreate'
 import { toggleTransactionsOnStatusChangeHook } from '@/hooks/trips/toggleTransactionsOnStatusChange'
+import { isAdmin } from './access/isAdmin'
 
 export const Trips: CollectionConfig = {
   slug: 'trips',
@@ -10,6 +11,9 @@ export const Trips: CollectionConfig = {
   admin: {
     useAsTitle: 'tripAt',
     defaultColumns: ['tripAt', 'from', 'areas', 'bottles', 'employee', 'status', 'pdf'],
+  },
+  access: {
+    delete: isAdmin,
   },
   hooks: {
     afterOperation: [createTransactionsOnTripCreate],
@@ -144,7 +148,7 @@ export const Trips: CollectionConfig = {
           'total',
           'status',
         ],
-      }
+      },
     },
   ],
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prevented duplication of entries in Areas, Blocks, Customers, Employees, Expenses, Invoices, and Transactions collections.
  * Restricted deletion of entries in Areas, Blocks, Employees, Expenses, Invoices, Transactions, and Trips collections to admin users only.

* **Style**
  * Minor formatting improvements for consistency in Customers, Transactions, and Trips collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->